### PR TITLE
Detect if getEntriesByType function exist to enable fallback

### DIFF
--- a/client/timing.js
+++ b/client/timing.js
@@ -13,7 +13,7 @@ define(function() {
     staticScope._support = {
         performance: !!window.performance,
         userTiming: window.performance && performance.mark,
-        resourceTiming: window.performance && performance.timing
+        resourceTiming: window.performance && (typeof(performance.getEntriesByType) == "function") && performance.timing
     };
 
     staticScope.mark = function(label) {


### PR DESCRIPTION
The library won't work in latest stable Firefox.
