### PR TITLE
Add XHR error handling for offline

### DIFF
--- a/lib/Http/HttpModule.js
+++ b/lib/Http/HttpModule.js
@@ -95,7 +95,7 @@ export default class HttpModule extends EventDispatcher {
             }
         });
 
-        this.on(['xhr-loadend', 'xhr-upload-loadend'], () => {
+        this.on(['xhr-loadend', 'xhr-upload-loadend', 'xhr-error'], () => {
             if (!this._requestingOverridden) {
                 this._requesting = false;
             }

--- a/lib/Http/LatencyModule.js
+++ b/lib/Http/LatencyModule.js
@@ -156,6 +156,10 @@ export default class LatencyModule extends HttpModule {
         // Measure the latency with the Resource Timing API once the request is finished
         if (supportsResourceTiming) {
             this.on('xhr-load', () => this._measure());
+            this.on('xhr-error', () => {
+                this._latencies.push(null);
+                this._nextRequest();
+            });
         }
 
         // If the browser doesn't support the Resource Timing API, we fallback on a Datetime solution.


### PR DESCRIPTION
My use case is if the browser becomes offline and the XHR requests begin to error, my JS app continues to run and watch for online availability.

This adds a hook to push `null` into the latency array if the XHR request responded with the error event, allowing the `net.latency.on( 'end' )` callback to receive `null` information and conclude there is no connection. Not sure if these needs to accommodate for intentional server errors, but it's an improvement in my case.